### PR TITLE
Add Heroku command to set NODE_ENV to the correct DB env

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "heroku-postbuild": "cd client && npm install && npm run build",
+    "heroku-postbuild": "cd client && npm install && npm run build && export NODE_ENV='lendit-prod'",
     "test": "export NODE_ENV='lendit-test' && mocha --recursive --exit && export NODE_ENV=undefined"
   },
   "repository": {


### PR DESCRIPTION
Before this, the lines that used NODE_ENV to connect to the
right database weren't being set for production. Added a line
in the heroku script to set the NODE_ENV to lendit-prod