### PR TITLE
Add response to post listing.

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,10 +33,14 @@ app.get('/api/items', async (req, res) => {
 
 
 app.post('/api/items', async (req, res, next) => {
-  const itemToCreate = { itemName: req.body.itemName }
-  const newItem = new Item(itemToCreate)
-  await newItem.save()
-  next();
+    const itemToCreate = { itemName: req.body.itemName }
+    const newItem = new Item(itemToCreate)
+    await newItem.save()
+    next();
+    res.send({
+        success: true,
+        message: 'Listing created'
+    });
 });
 
 const port = process.env.PORT || 5000;

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -42,7 +42,8 @@ class App extends React.Component {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(item)
-        })};
+        }).then(() => this.getItems());
+    };
 
     componentDidMount() {
         this.getItems();


### PR DESCRIPTION
Previously, we were getting a 404 when posting an item - this was
because while the server was configured correctly to update the mongo
database, it wasn't giving the frontend a response, so the frontend
404'd. Also added a line of code to the frontend to ensure that it runs
a GET request to get the new item from the database and display it