### PR TITLE
Fix bug - export NODE_ENV before building in Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "heroku-postbuild": "cd client && npm install && npm run build && export NODE_ENV='lendit-prod'",
+    "heroku-postbuild": "export NODE_ENV='lendit-prod' && cd client && npm install && npm run build",
     "test": "export NODE_ENV='lendit-test' && mocha --recursive --exit && export NODE_ENV=undefined"
   },
   "repository": {


### PR DESCRIPTION
Before this, export NODE_ENV='lendit-prod' was being set
after it was being installed and run build. Now it's at the
start of heroku-postbuild so it executes first